### PR TITLE
use latest version of o-charts (v0.2.2)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "d3": "~3.4.8",
     "backbone": "~1.1.2",
     "backbone.stickit": "~0.8.0",
-    "o-charts": "https://github.com/ft-interactive/o-charts.git#0.1.3",
+    "o-charts": "https://github.com/ft-interactive/o-charts.git#0.2.2",
     "jquery": "~2.1.3"
   },
   "version": "0.0.0"


### PR DESCRIPTION
simple change to bower.json so we use the latest version of o-charts.