### PR TITLE
Logic to choose charts based on the nature of the data.

### DIFF
--- a/src/scripts/models/GraphicType.js
+++ b/src/scripts/models/GraphicType.js
@@ -9,7 +9,8 @@ var GraphicType = Backbone.Model.extend({
     },
 
     defaults: {
-        typeName: ''
+        typeName: '',
+        suitabilityRanking: 0
     }
 });
 

--- a/src/scripts/views/GraphicVariation.js
+++ b/src/scripts/views/GraphicVariation.js
@@ -15,6 +15,7 @@ var ViewGraphicVariation = Backbone.View.extend({
     initialize: function (options) {
         this.chart = chartTypes[this.model.graphicType.get('typeName')];
         var debounced = _.bind(_.debounce(this.render, 50), this);
+        this.debouncedRender = debounced;
         this.listenTo(this.model.graphic, 'change', debounced);
         this.listenTo(this.model.graphic.chart.xAxis, 'change', debounced);
         this.listenTo(this.model.graphic.chart.yAxis, 'change', debounced);
@@ -31,6 +32,10 @@ var ViewGraphicVariation = Backbone.View.extend({
 
     events: {
         'click .graphic-container>svg.graphic': 'select'
+    },
+
+    cleanup: function() {
+        this.stopListening();
     },
 
     select: function (event) {

--- a/src/scripts/views/ImportData.js
+++ b/src/scripts/views/ImportData.js
@@ -97,6 +97,7 @@ var ViewImportData = Backbone.View.extend({
 
     remove: function () {
         this.undelegateEvents();
+        this.stopListening();
         return Backbone.View.prototype.remove.apply(this, arguments);
     },
 

--- a/src/scripts/views/IndependentAxisControls.js
+++ b/src/scripts/views/IndependentAxisControls.js
@@ -22,6 +22,10 @@ var ViewIndependantAxisControls = RegionView.extend({
         this.listenTo(this.dataImport.columns, 'reset', this.render);
     },
 
+    cleanup: function() {
+        this.stopListening();
+    },
+
     regions: {
         '[data-region="label"]': function () {
             return new ViewAxisLabel({

--- a/src/scripts/views/SelectedVariation.js
+++ b/src/scripts/views/SelectedVariation.js
@@ -27,6 +27,10 @@ var ViewSelectedVariation = RegionView.extend({
         this.listenTo(this.model.errors, 'reset', this.renderErrors);
     },
 
+    cleanup: function() {
+        this.stopListening();
+    },
+
     className: 'view-selected-variation',
 
     template: require('./../templates/selected-variation.hbs'),

--- a/src/scripts/views/SeriesList.js
+++ b/src/scripts/views/SeriesList.js
@@ -168,6 +168,10 @@ var ViewSeriesList = CollectionView.extend({
             this.listenTo(this.model, 'change:isOther', this.updateClassName);
         },
 
+        cleanup: function() {
+            this.stopListening();
+        },
+
         className: function () {
             return 'view-series-list-item series-' + (this.model.get('isOther') ? 'other' : this.index + 1);
         },


### PR DESCRIPTION
- [x] Added logic to choose which charts to show the user first depending on the timespan and number of points.
- [x] Added cleanup method to views so that they can be called by their collectionView parents to unbind the views listeners in order to avoid memory leaks.


The choice logic is as follows:
* if we aren't doing monthly, quarterly or yearly data intervals, we show *Line* charts first.
* if the date range of the data (the difference between the last and first data point) is larger than 15 intervals (months, quarters or years), then show *Line* charts.
* Otherwise, show *Column* charts.

Please bear in mind that I chose 15 as an arbitrary number, which can be tweaked.