### PR TITLE
use new version of o-charts (0.3.1) fixes #15

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "d3": "~3.4.8",
     "backbone": "~1.1.2",
     "backbone.stickit": "~0.8.0",
-    "o-charts": "https://github.com/ft-interactive/o-charts.git#0.2.3",
+    "o-charts": "https://github.com/ft-interactive/o-charts.git#0.3.1",
     "jquery": "~2.1.3"
   },
   "version": "0.0.0"


### PR DESCRIPTION
Includes all of the collision detection fixes added on the latest version of o-charts