### PR TITLE
use column as default sorting

### DIFF
--- a/src/scripts/models/import.js
+++ b/src/scripts/models/import.js
@@ -112,7 +112,7 @@ var DataImport = Backbone.Model.extend({
         dataAsString: '',
         numRows: 0,
         numCols: 0,
-        recommendedChartStyle: 'Line',
+        recommendedChartStyle: 'Column',
         colNames: [],
         pipelineOptions: null,
         warning: {


### PR DESCRIPTION
Since line charts will only be chosen on time series data that’s either daily or spans a very long time, we make column charts the default choice, which gives us the right ordering for free on categorical charts, and still displays the line chart first when the right conditions are met.