### PR TITLE
make datatype switch affect ordering of charts

### DIFF
--- a/src/scripts/models/import.js
+++ b/src/scripts/models/import.js
@@ -130,6 +130,22 @@ var DataImport = Backbone.Model.extend({
         this.listenTo(this, 'invalid', this.discardData);
     },
 
+    recomputeRecommendedChartStyle: function() {
+        var typeInfo,
+            recommendedChartStyle = 'Column';
+
+        for (var i = 0, l = this.columns.length; i < l; i++) {
+            typeInfo = this.columns.at(i).get('typeInfo');
+            if (typeInfo.dataType === DataTypes.TIME) {
+                if (typeInfo.mostPopularDateFormat && typeInfo.predictedAxis === Axis.X) {
+                    recommendedChartStyle = findRecommendedChartStyle(typeInfo);
+                }
+            }
+        }
+
+        this.set('recommendedChartStyle', recommendedChartStyle);
+    },
+
     validate: function (attributes, options) {
 
         var file = new ValidateFile(attributes);

--- a/src/scripts/nightingale.js
+++ b/src/scripts/nightingale.js
@@ -80,13 +80,13 @@ function init() {
         graphic.set(expectedValues);
     });
 
-    importData.on('change:data', function (model, data) {
+    importData.on('change:recommendedChartStyle', function(model, recommendedChartStyle) {
         // work out what style is recommended.
         var chartStyle = model.get('recommendedChartStyle');
         // and sort our chart types based on that.
 
         types.forEach(function(t) {
-            if (t.get('typeName') == chartStyle) {
+            if (t.get('typeName') === chartStyle) {
                 t.set('suitabilityRanking', -100, {silent : true});
                 t.set('recommended', true);
             } else {
@@ -95,7 +95,9 @@ function init() {
             }
         });
         types.sort();
+    });
 
+    importData.on('change:data', function (model, data) {
         // then set the data which triggers rendering
         graphic.chart.dataset.set('rows', data);
     });

--- a/src/scripts/views/IndependentAxisControls.js
+++ b/src/scripts/views/IndependentAxisControls.js
@@ -20,6 +20,19 @@ var ViewIndependantAxisControls = RegionView.extend({
             }
         });
         this.listenTo(this.dataImport.columns, 'reset', this.render);
+        this.listenTo(this.model, 'change:dataType', function(model, dataType) {
+            switch (dataType) {
+                case 'categorical':
+                    options.dataImport.set('recommendedChartStyle', 'Column');
+                    break;
+                case 'numeric':
+                    options.dataImport.set('recommendedChartStyle', 'Column');
+                    break;
+                default:
+                    this.dataImport.recomputeRecommendedChartStyle();
+                    break;
+            }
+        });
     },
 
     cleanup: function() {


### PR DESCRIPTION
Switching data type to categorical wasn't reordering the charts to show column at the top. Now that's changed:

![image](https://dl.dropboxusercontent.com/u/5746285/change_styles.gif)