### PR TITLE
return null when using dashes rather than NaNs, use new o-charts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "d3": "~3.4.8",
     "backbone": "~1.1.2",
     "backbone.stickit": "~0.8.0",
-    "o-charts": "https://github.com/ft-interactive/o-charts.git#0.3.3",
+    "o-charts": "https://github.com/ft-interactive/o-charts.git#0.3.4",
     "jquery": "~2.1.3"
   },
   "version": "0.0.0"

--- a/src/scripts/transform/number.js
+++ b/src/scripts/transform/number.js
@@ -27,7 +27,7 @@ function createNumberTransformer(options) {
 
         if (d === '') return _NaN;
 
-        if (d === '*') return null;
+        if (/^[*:-]$/.test(d)) return null;
 
         return Number(d);
 


### PR DESCRIPTION
Turns out the n/a placement bug was to do with the fact that we were passing `NaN` to the plot scale rather than nulls, which means that the call `maxValue = Math.max(0, NaN)` was returning NaN rather than null.

The `NaN`s were coming from the fact that we had forgotten to parse `-` and `:` as nulls. That is now fixed so everything should work ok.

This fixes https://github.com/ft-interactive/o-charts/issues/57