### PR TITLE
Renamed "Nice" option to be more self-explanatory

### DIFF
--- a/src/scripts/templates/type-controls-line.hbs
+++ b/src/scripts/templates/type-controls-line.hbs
@@ -10,7 +10,7 @@
 </div>
 <div class="checkbox">
     <label>
-        <input type="checkbox" name="nice">Nice
+        <input type="checkbox" name="nice">Round values for Y axis
     </label>
 </div>
 <div class="checkbox">


### PR DESCRIPTION
Now it reads "Use nice round values for Y axis" which should be more accessible to non-d3 gurus.