### PR TITLE
hotfix for sorting charts

### DIFF
--- a/src/scripts/nightingale.js
+++ b/src/scripts/nightingale.js
@@ -101,10 +101,10 @@ function init(email) {
 
         types.forEach(function(t) {
             if (t.get('typeName') === chartStyle) {
-                t.set('suitabilityRanking', t.get('suitabilityRanking') - 100, {silent : true});
+                t.set('suitabilityRanking', - 100, {silent : true});
                 t.set('recommended', true);
             } else {
-                t.set('suitabilityRanking', t.get('suitabilityRanking') + 100, {silent : true});
+                t.set('suitabilityRanking', 100, {silent : true});
                 t.set('recommended', false);
             }
         });


### PR DESCRIPTION
I introduced a regression where the recommended chart would not appear at the top after changing data a couple of times (i.e. switching from a recommended line chart to a bar chart). This fixes it.