### PR TITLE
Firefox Fix (Pasting clipboard data)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test/smoke/**/*.png
 test/screenshots/*.png
 test/functional/screenshots/*.png
 test/bin/*.jar
+.DS_Store

--- a/src/scripts/templates/import.hbs
+++ b/src/scripts/templates/import.hbs
@@ -2,7 +2,7 @@
     <h1 class="text-center import-data-title">Import data</h1>
 
     <div class="warning-message"></div>
-    <div class="fake-field">
+    <div class="fake-field" contenteditable="true">
         <p class="fake-field__placeholder">Copy and paste a range of cells from Excel...</p>
     </div>
     <div class="form-group">

--- a/src/scripts/views/ImportData.js
+++ b/src/scripts/views/ImportData.js
@@ -35,6 +35,7 @@ var ViewImportData = Backbone.View.extend({
         }).bind(this);
         this.__paste = (function (event) {
             var clipboardData = event.clipboardData;
+            event.preventDefault();
             if (!clipboardData) return;
             var types = clipboardData.types;
             var data;
@@ -43,7 +44,9 @@ var ViewImportData = Backbone.View.extend({
                 if (data) {
                     this.model.set({dataAsString: data}, {validate: true});
                 }
+
             }
+
         }).bind(this);
         window.addEventListener('dragover', this.__dragover, false);
         var self = this;


### PR DESCRIPTION
Will allow Firefox to paste content into the fake-field. Contrary to spec (I think) Firefox only emits a paste event on and element that is editable.